### PR TITLE
Update README to match new BIP process

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -7,12 +7,11 @@ href="bip-update-process.md">tk: BIP Update Process</a> for the full process.
 
 The BIPs repository serves as a publication medium and archive. Having a BIP published here indicates that the proposal
 is in scope and has met other formal criteria for this repository, but does not indicate that it is a good idea, has
-community consensus, or that it is about to be adopted. The BIP Editors are expected to be liberal with approving BIPs
-and try not to be too involved in decision-making on behalf of the community. Beyond the formal criteria, evaluation of
-the proposals is left to the audience of the repository. The exceptions are rare cases when a decision is contentious
-and cannot be agreed upon. In those cases, the conservative option will be preferred. Authors proposing changes should
-consider that ultimately, consent rests with the Bitcoin users (see also: [https://en.bitcoin.it/wiki/Economic_majority
-economic majority]).
+community consensus, or that it is about to be adopted. The BIP Editors are expected to be liberal with accepting BIPs
+and not to be too involved in decision-making on behalf of the community. Beyond the formal criteria, evaluation of
+proposals is left to the audience of the repository. When a proposal is controversial, but deemed high-quality and in
+scope, the BIP Editors shall err on the side of merging it. Ultimately, consent and adoption rests with the Bitcoin
+users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority]).
 
 {| class="wikitable sortable" style="width: auto; text-align: center; font-size: smaller; table-layout: fixed;"
 !Number

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -1,10 +1,18 @@
-People wishing to submit BIPs, first should propose their idea or document to the [https://groups.google.com/g/bitcoindev bitcoindev@googlegroups.com] mailing list (do <em>not</em> assign a number - read <a href="bip-0002.mediawiki">BIP 2</a> for the full process). After discussion, please open a PR. After copy-editing and acceptance, it will be published here.
+People wishing to submit BIPs should first describe their idea to the [https://groups.google.com/g/bitcoindev
+bitcoindev@googlegroups.com] mailing list. Please open a pull request to this repository only when substantial progress
+on the draft has been made, preferably when the draft is nearing completion. After a proposal meets the editorial
+criteria, a BIP Editor will assign a number to it, and publish the proposal by merging the pull request to the
+repository. Authors do <em>not</em> assign a number to their own proposal. Please see <a
+href="bip-update-process.md">tk: BIP Update Process</a> for the full process.
 
-We are fairly liberal with approving BIPs, and try not to be too involved in decision making on behalf of the community. The exception is in very rare cases of dispute resolution when a decision is contentious and cannot be agreed upon. In those cases, the conservative option will always be preferred.
-
-Having a BIP here does not make it a formally accepted standard until its status becomes Final or Active.
-
-Those proposing changes should consider that ultimately consent may rest with the consensus of the Bitcoin users (see also: [https://en.bitcoin.it/wiki/Economic_majority economic majority]).
+The BIPs repository serves as a publication medium and archive. Having a BIP published here indicates that the proposal
+is in scope and has met other formal criteria for this repository, but does not indicate that it is a good idea, has
+community consensus, or that it is about to be adopted. The BIP Editors are expected to be liberal with approving BIPs
+and try not to be too involved in decision-making on behalf of the community. Beyond the formal criteria, evaluation of
+the proposals is left to the audience of the repository. The exceptions are rare cases when a decision is contentious
+and cannot be agreed upon. In those cases, the conservative option will be preferred. Authors proposing changes should
+consider that ultimately, consent rests with the Bitcoin users (see also: [https://en.bitcoin.it/wiki/Economic_majority
+economic majority]).
 
 {| class="wikitable sortable" style="width: auto; text-align: center; font-size: smaller; table-layout: fixed;"
 !Number


### PR DESCRIPTION
If and when the proposal for an updated BIP process gets adopted by the Bitcoin community, this PR will be used to update it’s status and update the README accordingly.